### PR TITLE
Remove maps

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,6 @@
 	<title>Jackson Obedience Training Club | JOTC</title>
 	
 	<!-- bower:css -->
-	<link rel="stylesheet" href="bower_components/font-awesome/css/font-awesome.css" />
 	<!-- endbower -->
 	<link rel="stylesheet" type="text/css" href="style/main.css">
 </head>

--- a/js/partials.js
+++ b/js/partials.js
@@ -330,14 +330,9 @@ angular.module('jotc-partials', []).run(['$templateCache', function($templateCac
     "\t\t\t\t\t\t\t<span ng-click=\"classes.edit(class);\">edit</span> |\n" +
     "\t\t\t\t\t\t\t<span ng-click=\"classes.remove(class);\">delete</span> ]</span>\n" +
     "\t\t\t\t\t</div>\n" +
-    "\t\t\t\t\t<div class=\"map\">\n" +
-    "\t\t\t\t\t\t<a href=\"{{ $location.getDirectionsURLForLocation(class.location) }}\" target=\"_blank\">\n" +
-    "\t\t\t\t\t\t\t<img ng-src=\"{{ $location.getImageURLForLocation(class.location); }}\">\n" +
-    "\t\t\t\t\t\t\t<br> Click for directions\n" +
-    "\t\t\t\t\t\t</a>\n" +
-    "\t\t\t\t\t</div>\n" +
     "\t\t\t\t\t<div class=\"location\">\n" +
-    "\t\t\t\t\t\t{{ class.location }}\n" +
+    "\t\t\t\t\t\t<a href=\"{{ $location.getDirectionsURLForLocation(class.location) }}\" target=\"_blank\">{{ class.location }} <i class=\"fas fa-map-marked-alt\"></i><br/>\n" +
+    "\t\t\t\t\t\t<span style=\"font-weight: normal; size: 0.8em;\">Click for directions</span></a>\n" +
     "\t\t\t\t\t</div>\n" +
     "\t\t\t\t\t<div class=\"description\">\n" +
     "\t\t\t\t\t\t<span ng-repeat=\"description in getDescriptionBlocks(class)\" style=\"white-space: pre-line;\">\n" +

--- a/sections/classes/template.html
+++ b/sections/classes/template.html
@@ -38,14 +38,9 @@
 							<span ng-click="classes.edit(class);">edit</span> |
 							<span ng-click="classes.remove(class);">delete</span> ]</span>
 					</div>
-					<div class="map">
-						<a href="{{ $location.getDirectionsURLForLocation(class.location) }}" target="_blank">
-							<img ng-src="{{ $location.getImageURLForLocation(class.location); }}">
-							<br> Click for directions
-						</a>
-					</div>
 					<div class="location">
-						{{ class.location }}
+						<a href="{{ $location.getDirectionsURLForLocation(class.location) }}" target="_blank">{{ class.location }} <i class="fas fa-map-marked-alt"></i><br/>
+						<span style="font-weight: normal; size: 0.8em;">Click for directions</span></a>
 					</div>
 					<div class="description">
 						<span ng-repeat="description in getDescriptionBlocks(class)" style="white-space: pre-line;">


### PR DESCRIPTION
Google Maps are no longer free.  The free alternatives cannot geocode from a location name/address into a map location.  There may be a better long-term solution, but for now, just disable maps and instead turn the entire location text into a link.

<img width="568" alt="screen shot 2018-08-21 at 7 30 34 pm" src="https://user-images.githubusercontent.com/1775733/44436061-b4a26400-a578-11e8-99f7-a1283b89dcb0.png">
